### PR TITLE
Align our CEPH Caching plugin with the latest DLF features

### DIFF
--- a/plugins/ceph-cache-plugin/deploy/rook/cluster-on-pvc.yaml
+++ b/plugins/ceph-cache-plugin/deploy/rook/cluster-on-pvc.yaml
@@ -33,7 +33,7 @@ spec:
             storage: 4Gi
   cephVersion:
     #image: ceph/ceph:v15.2
-    image: quay.io/ibm-dlf/ceph-daemon:pullrequest-amd64
+    image: quay.io/ibm-dlf/ceph-daemon:g3b029ab85d-amd64
     allowUnsupported: true
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false

--- a/plugins/ceph-cache-plugin/deploy/rook/cluster.yaml
+++ b/plugins/ceph-cache-plugin/deploy/rook/cluster.yaml
@@ -22,7 +22,7 @@ spec:
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
     # If you want to be more precise, you can always use a timestamp tag such ceph/ceph:v14.2.5-20190917
     # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
-    image: quay.io/ibm-dlf/ceph-daemon:pullrequest-amd64
+    image: quay.io/ibm-dlf/ceph-daemon:g3b029ab85d-amd64
     # Whether to allow unsupported versions of Ceph. Currently mimic and nautilus are supported, with the recommendation to upgrade to nautilus.
     # Octopus is the version allowed when this is set to true.
     # Do not set to true in production.

--- a/plugins/ceph-cache-plugin/go.mod
+++ b/plugins/ceph-cache-plugin/go.mod
@@ -3,14 +3,14 @@ module ceph-cache-plugin
 go 1.13
 
 require (
-	github.com/IBM/dataset-lifecycle-framework/src/dataset-operator v0.0.0-20200608144651-28bcf38edd7e
+	github.com/IBM/dataset-lifecycle-framework/src/dataset-operator v0.0.0-20210211155337-73ae2088ed27
 	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/operator-framework/operator-sdk v0.16.0
 	github.com/rook/rook v1.3.3
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 // indirect
 	k8s.io/api v0.17.2
-	k8s.io/apimachinery v0.17.2
+	k8s.io/apimachinery v0.17.3
 	k8s.io/client-go v12.0.0+incompatible
 	sigs.k8s.io/controller-runtime v0.5.1
 )

--- a/plugins/ceph-cache-plugin/go.sum
+++ b/plugins/ceph-cache-plugin/go.sum
@@ -31,6 +31,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced34534/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
 github.com/IBM/dataset-lifecycle-framework/src/dataset-operator v0.0.0-20200608144651-28bcf38edd7e h1:uZ3yivLKCrjv1GA6TgP0ZZuCywZ6v/hPYg6bBqKqw4Q=
 github.com/IBM/dataset-lifecycle-framework/src/dataset-operator v0.0.0-20200608144651-28bcf38edd7e/go.mod h1:3cgYNkxu4biBO+naj0dFEFcJm9FiFwCj3W7dBtayETY=
+github.com/IBM/dataset-lifecycle-framework/src/dataset-operator v0.0.0-20210211155337-73ae2088ed27 h1:uIJ89FI6MRXYrXHsrw9Ij7+0MlI1BMnymXmeqsNZf4M=
+github.com/IBM/dataset-lifecycle-framework/src/dataset-operator v0.0.0-20210211155337-73ae2088ed27/go.mod h1:0PMq2AjWBeGhpdOchqu8441DFCuWqqNop12/SeGscsw=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
@@ -293,6 +295,7 @@ github.com/go-openapi/spec v0.19.2/go.mod h1:sCxk3jxKgioEJikev4fgkNmwS+3kuYdJtcs
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/spec v0.19.4 h1:ixzUSnHTd6hCemgtAJgluaTSGYpLNpJY4mA2DIkdOAo=
 github.com/go-openapi/spec v0.19.4/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
+github.com/go-openapi/spec v0.19.5/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.19.0/go.mod h1:+uW+93UVvGGq2qGaZxdDeJqSAqBqBdl+ZPMF/cC8nDY=
@@ -667,6 +670,7 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -1094,6 +1098,8 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.1.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
@@ -1194,5 +1200,6 @@ sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9
 sigs.k8s.io/testing_frameworks v0.1.2/go.mod h1:ToQrwSC3s8Xf/lADdZp3Mktcql9CG0UAmdJG9th5i0w=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/plugins/ceph-cache-plugin/pkg/controller/dataset/ceph_related_objects.go
+++ b/plugins/ceph-cache-plugin/pkg/controller/dataset/ceph_related_objects.go
@@ -11,61 +11,64 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func createCustomConfigMapForRados(c client.Client,dataset *comv1alpha1.Dataset) error{
+func createCustomConfigMapForRados(c client.Client, dataset *comv1alpha1.Dataset) error {
 	accessKeyID := dataset.Spec.Local["accessKeyID"]
 	secretAccessKey := dataset.Spec.Local["secretAccessKey"]
 	endpoint := dataset.Spec.Local["endpoint"]
 	bucket := dataset.Spec.Local["bucket"]
+	region := dataset.Spec.Local["region"]
 
 	configMapForRados := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "rook-ceph-rgw-"+dataset.Name+"-custom",
+			Name:      "rook-ceph-rgw-" + dataset.Name + "-custom",
 			Namespace: os.Getenv("ROOK_NAMESPACE"),
 			Labels: map[string]string{
-				"dataset": dataset.Name,
+				"dataset":           dataset.Name,
 				"dataset-namespace": dataset.Namespace,
-				"dataset-uid": string(dataset.UID),
+				"dataset-uid":       string(dataset.UID),
 			},
 		},
 		Data: map[string]string{
-			"config": "\n[global]\nrgw frontends = civetweb port=8000\nadmin socket = /tmp/radosgw.8000.asok\nremote s3 = "+endpoint+"\nremote bucket = "+bucket+"\nremote id = "+accessKeyID+"\nremote secret = "+secretAccessKey+"\n",
+			"config": "\n[global]\nrgw frontends = civetweb port=8000\nadmin socket = /tmp/radosgw.8000.asok\nremote s3 = " +
+				endpoint + "\nremote bucket = " + bucket + "\nremote id = " + accessKeyID + "\nremote secret = " +
+				secretAccessKey + "\nremote region = " + region + "\n",
 		},
 	}
-	err := c.Create(context.TODO(),	configMapForRados)
-	return err;
+	err := c.Create(context.TODO(), configMapForRados)
+	return err
 }
 
-func createCephObjectStore(c client.Client,dataset *comv1alpha1.Dataset) error{
+func createCephObjectStore(c client.Client, dataset *comv1alpha1.Dataset) error {
 
 	log.Info("Creating ceph object store")
 
 	newRgw := &cephv1.CephObjectStore{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: dataset.ObjectMeta.Name,
+			Name:      dataset.ObjectMeta.Name,
 			Namespace: os.Getenv("ROOK_NAMESPACE"),
 			Labels: map[string]string{
-				"dataset": dataset.Name,
+				"dataset":           dataset.Name,
 				"dataset-namespace": dataset.Namespace,
-				"dataset-uid": string(dataset.UID),
+				"dataset-uid":       string(dataset.UID),
 			},
 		},
-		Spec:       cephv1.ObjectStoreSpec{
-			MetadataPool:          cephv1.PoolSpec{
+		Spec: cephv1.ObjectStoreSpec{
+			MetadataPool: cephv1.PoolSpec{
 				FailureDomain: "host",
-				Replicated:      cephv1.ReplicatedSpec{
-					Size:                   1,
+				Replicated: cephv1.ReplicatedSpec{
+					Size: 1,
 				},
 			},
-			DataPool:              cephv1.PoolSpec{
+			DataPool: cephv1.PoolSpec{
 				FailureDomain: "host",
-				Replicated:      cephv1.ReplicatedSpec{
-					Size:                   1,
+				Replicated: cephv1.ReplicatedSpec{
+					Size: 1,
 				},
 			},
 			PreservePoolsOnDelete: false,
-			Gateway:               cephv1.GatewaySpec{
+			Gateway: cephv1.GatewaySpec{
 				Instances: 1,
-				Port: 80,
+				Port:      80,
 			},
 		},
 	}
@@ -103,48 +106,48 @@ func createCephObjectStore(c client.Client,dataset *comv1alpha1.Dataset) error{
 	return err
 }
 
-func createCephObjectStoreUser(c client.Client, dataset *comv1alpha1.Dataset) error{
+func createCephObjectStoreUser(c client.Client, dataset *comv1alpha1.Dataset) error {
 
 	log.Info("Creating ceph object store user")
 
 	cephObjectStoreUser := &cephv1.CephObjectStoreUser{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: dataset.ObjectMeta.Name,
+			Name:      dataset.ObjectMeta.Name,
 			Namespace: os.Getenv("ROOK_NAMESPACE"),
 			Labels: map[string]string{
-				"dataset": dataset.Name,
+				"dataset":           dataset.Name,
 				"dataset-namespace": dataset.Namespace,
-				"dataset-uid": string(dataset.UID),
+				"dataset-uid":       string(dataset.UID),
 			},
 		},
-		Spec:       cephv1.ObjectStoreUserSpec{
+		Spec: cephv1.ObjectStoreUserSpec{
 			Store:       dataset.ObjectMeta.Name,
 			DisplayName: "Ceph User",
 		},
 	}
 
-	err := c.Create(context.TODO(),cephObjectStoreUser)
-	return err;
+	err := c.Create(context.TODO(), cephObjectStoreUser)
+	return err
 }
 
-func isSameCephObject(labels map[string]string, datasetInstance *comv1alpha1.Dataset) (bool){
+func isSameCephObject(labels map[string]string, datasetInstance *comv1alpha1.Dataset) bool {
 	sameObj := true
-	if(labels==nil){
+	if labels == nil {
 		sameObj = false
 		log.Info("Doesn't have labels")
 	} else {
-		if(labels["dataset"]!=datasetInstance.ObjectMeta.Name){
+		if labels["dataset"] != datasetInstance.ObjectMeta.Name {
 			sameObj = false
 			log.Info("Not the same dataset name")
-			log.Info("Dataset name "+datasetInstance.ObjectMeta.Name)
-		} else if(labels["dataset-namespace"]!=datasetInstance.ObjectMeta.Namespace){
+			log.Info("Dataset name " + datasetInstance.ObjectMeta.Name)
+		} else if labels["dataset-namespace"] != datasetInstance.ObjectMeta.Namespace {
 			sameObj = false
 			log.Info("Not the same dataset namespace")
-			log.Info("Dataset namespace "+datasetInstance.ObjectMeta.Name)
-		} else if(labels["dataset-uid"]!=string(datasetInstance.ObjectMeta.UID)) {
+			log.Info("Dataset namespace " + datasetInstance.ObjectMeta.Name)
+		} else if labels["dataset-uid"] != string(datasetInstance.ObjectMeta.UID) {
 			sameObj = false
 			log.Info("Not the same dataset uid")
-			log.Info("Dataset uid "+string(datasetInstance.ObjectMeta.UID))
+			log.Info("Dataset uid " + string(datasetInstance.ObjectMeta.UID))
 		}
 	}
 	return sameObj

--- a/plugins/ceph-cache-plugin/pkg/controller/dataset/dataset_controller.go
+++ b/plugins/ceph-cache-plugin/pkg/controller/dataset/dataset_controller.go
@@ -22,7 +22,7 @@ import (
 
 var log = logf.Log.WithName("controller_dataset")
 
-var reqLogger = log.WithValues("global","logger")
+var reqLogger = log.WithValues("global", "logger")
 
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
@@ -99,7 +99,7 @@ func (r *ReconcileDataset) Reconcile(request reconcile.Request) (reconcile.Resul
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
-            return reconcile.Result{}, nil
+			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
@@ -138,81 +138,80 @@ func (r *ReconcileDataset) Reconcile(request reconcile.Request) (reconcile.Resul
 	reqLogger.Info("Dataset internal not ready yet, we should provision")
 
 	clusterList := &cephv1.CephClusterList{}
-	err = populateListOfObjects(r.client,clusterList,[]client.ListOption{
-			client.InNamespace(os.Getenv("ROOK_NAMESPACE")),
+	err = populateListOfObjects(r.client, clusterList, []client.ListOption{
+		client.InNamespace(os.Getenv("ROOK_NAMESPACE")),
 	})
-	if(err!=nil){
-		errAdd := addErrorToDataset(r.client,"cannot lookup ceph clusters", datasetInstance)
-		if(errAdd != nil){
+	if err != nil {
+		errAdd := addErrorToDataset(r.client, "cannot lookup ceph clusters", datasetInstance)
+		if errAdd != nil {
 			return reconcile.Result{}, errAdd
 		}
 		return reconcile.Result{}, err
-	} else if(len(clusterList.Items)==0) {
-		errAdd := addErrorToDataset(r.client,"no ceph clusters available", datasetInstance)
-		if(errAdd != nil){
+	} else if len(clusterList.Items) == 0 {
+		errAdd := addErrorToDataset(r.client, "no ceph clusters available", datasetInstance)
+		if errAdd != nil {
 			return reconcile.Result{}, errAdd
 		}
 		return reconcile.Result{}, errors.NewBadRequest("no ceph clusters available")
 	}
 
-
 	configMapForRados := &corev1.ConfigMap{}
-	err = getExactlyOneObject(r.client,configMapForRados,"rook-ceph-rgw-"+request.Name+"-custom",os.Getenv("ROOK_NAMESPACE"))
-	if(errors.IsNotFound(err)){
+	err = getExactlyOneObject(r.client, configMapForRados, "rook-ceph-rgw-"+request.Name+"-custom", os.Getenv("ROOK_NAMESPACE"))
+	if errors.IsNotFound(err) {
 		reqLogger.Info("errors.IsNotFound(err) object store")
-		errCreation := createCustomConfigMapForRados(r.client,datasetInstance)
-		if(errCreation!=nil){
+		errCreation := createCustomConfigMapForRados(r.client, datasetInstance)
+		if errCreation != nil {
 			return reconcile.Result{}, errCreation
 		}
-		return reconcile.Result{Requeue: true},nil
-	} else if(err!=nil) {
+		return reconcile.Result{Requeue: true}, nil
+	} else if err != nil {
 		reqLogger.Info("Generic error for getting ceph object store, shouldn't happen")
 		return reconcile.Result{}, err
-	} else{
+	} else {
 		reqLogger.Info("Found one, but lets check if they belog to the same dataset")
-		sameObj := isSameCephObject(configMapForRados.Labels,datasetInstance)
-		if(sameObj==false){
+		sameObj := isSameCephObject(configMapForRados.Labels, datasetInstance)
+		if sameObj == false {
 			return reconcile.Result{}, errors.NewBadRequest("rgw exists, but belongs to different dataset")
 		}
 		reqLogger.Info("Found the correct rgw, all good")
 	}
 
 	cephObjectStore := &cephv1.CephObjectStore{}
-	err = getExactlyOneObject(r.client,cephObjectStore,request.Name,os.Getenv("ROOK_NAMESPACE"))
-	if(errors.IsNotFound(err)){
+	err = getExactlyOneObject(r.client, cephObjectStore, request.Name, os.Getenv("ROOK_NAMESPACE"))
+	if errors.IsNotFound(err) {
 		reqLogger.Info("errors.IsNotFound(err) object store")
-		errCreation := createCephObjectStore(r.client,datasetInstance)
-		if(errCreation!=nil){
+		errCreation := createCephObjectStore(r.client, datasetInstance)
+		if errCreation != nil {
 			return reconcile.Result{}, errCreation
 		}
-		return reconcile.Result{Requeue: true},nil
-	} else if(err!=nil) {
+		return reconcile.Result{Requeue: true}, nil
+	} else if err != nil {
 		reqLogger.Info("Generic error for getting ceph object store, shouldn't happen")
 		return reconcile.Result{}, err
-	} else{
+	} else {
 		reqLogger.Info("Found one, but lets check if they belog to the same dataset")
-		sameObj := isSameCephObject(cephObjectStore.Labels,datasetInstance)
-		if(sameObj==false){
+		sameObj := isSameCephObject(cephObjectStore.Labels, datasetInstance)
+		if sameObj == false {
 			return reconcile.Result{}, errors.NewBadRequest("rgw exists, but belongs to different dataset")
 		}
-		if(cephObjectStore.Status==nil){
+		if cephObjectStore.Status == nil {
 			reqLogger.Info("Rgw not ready, requeing")
 			return reconcile.Result{Requeue: true}, nil
 		}
-		if(cephObjectStore.Status!=nil && cephObjectStore.Status.Phase!="Connected"){
+		if cephObjectStore.Status != nil && cephObjectStore.Status.Phase != "Connected" {
 			reqLogger.Info("Rgw not ready, requeing")
 			return reconcile.Result{Requeue: true}, nil
 		}
 		rgwPods := &corev1.PodList{}
-		err = populateListOfObjects(r.client,rgwPods,[]client.ListOption{
+		err = populateListOfObjects(r.client, rgwPods, []client.ListOption{
 			client.InNamespace(os.Getenv("ROOK_NAMESPACE")),
-			client.MatchingLabels{"app":"rook-ceph-rgw","rgw": request.Name},
+			client.MatchingLabels{"app": "rook-ceph-rgw", "rgw": request.Name},
 		})
-		if(err!=nil){
+		if err != nil {
 			reqLogger.Info("Error getting list of pods for rgw")
 			return reconcile.Result{}, err
 		} else {
-			if(len(rgwPods.Items)==0){
+			if len(rgwPods.Items) == 0 {
 				reqLogger.Info("Rgw pod not ready, requeing")
 				return reconcile.Result{Requeue: true}, nil
 			}
@@ -221,21 +220,21 @@ func (r *ReconcileDataset) Reconcile(request reconcile.Request) (reconcile.Resul
 	}
 
 	cephObjectStoreUser := &cephv1.CephObjectStoreUser{}
-	err = getExactlyOneObject(r.client,cephObjectStoreUser,request.Name,os.Getenv("ROOK_NAMESPACE"))
-	if(errors.IsNotFound(err)){
+	err = getExactlyOneObject(r.client, cephObjectStoreUser, request.Name, os.Getenv("ROOK_NAMESPACE"))
+	if errors.IsNotFound(err) {
 		reqLogger.Info("errors.IsNotFound(err) object store")
-		errCreation := createCephObjectStoreUser(r.client,datasetInstance)
-		if(errCreation!=nil){
+		errCreation := createCephObjectStoreUser(r.client, datasetInstance)
+		if errCreation != nil {
 			return reconcile.Result{}, errCreation
 		}
-		return reconcile.Result{Requeue: true},nil
-	} else if(err!=nil) {
+		return reconcile.Result{Requeue: true}, nil
+	} else if err != nil {
 		reqLogger.Info("Generic error for getting ceph object storeUser, shouldn't happen")
 		return reconcile.Result{}, err
 	} else {
 		reqLogger.Info("Found one, but lets check if they belog to the same dataset")
-		sameObj := isSameCephObject(cephObjectStoreUser.Labels,datasetInstance)
-		if(sameObj==false){
+		sameObj := isSameCephObject(cephObjectStoreUser.Labels, datasetInstance)
+		if sameObj == false {
 			return reconcile.Result{}, errors.NewBadRequest("rgw exists, but belongs to different dataset")
 		}
 		reqLogger.Info("Found the correct rgw, all good")
@@ -243,12 +242,12 @@ func (r *ReconcileDataset) Reconcile(request reconcile.Request) (reconcile.Resul
 
 	associatedCephUserSecrets := &corev1.Secret{}
 	err = r.client.Get(context.TODO(), types.NamespacedName{
-		Name: "rook-ceph-object-user-"+datasetInstance.ObjectMeta.Name+"-"+datasetInstance.ObjectMeta.Name,
+		Name:      "rook-ceph-object-user-" + datasetInstance.ObjectMeta.Name + "-" + datasetInstance.ObjectMeta.Name,
 		Namespace: os.Getenv("ROOK_NAMESPACE")},
 		associatedCephUserSecrets)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("ceph user secrets not created yet, requeing")
-		return reconcile.Result{Requeue: true},nil
+		return reconcile.Result{Requeue: true}, nil
 		// Secrets created successfully - don't requeue
 	} else if err != nil {
 		return reconcile.Result{}, err
@@ -263,18 +262,18 @@ func (r *ReconcileDataset) Reconcile(request reconcile.Request) (reconcile.Resul
 
 	associatedRgwService := &corev1.Service{}
 	err = r.client.Get(context.TODO(), types.NamespacedName{
-		Name: "rook-ceph-rgw-"+datasetInstance.ObjectMeta.Name,
+		Name:      "rook-ceph-rgw-" + datasetInstance.ObjectMeta.Name,
 		Namespace: os.Getenv("ROOK_NAMESPACE")}, associatedRgwService)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("RGW service not found, requing")
-		return reconcile.Result{Requeue: true},nil
+		return reconcile.Result{Requeue: true}, nil
 		// Secrets created successfully - don't requeue
 	} else if err != nil {
 		return reconcile.Result{}, err
 	} else {
-		if(len(associatedRgwService.OwnerReferences)>0 && associatedRgwService.OwnerReferences[0].UID!=cephObjectStore.UID){
+		if len(associatedRgwService.OwnerReferences) > 0 && associatedRgwService.OwnerReferences[0].UID != cephObjectStore.UID {
 			reqLogger.Info("RgwService with different parent, requing")
-			return reconcile.Result{Requeue: true},nil
+			return reconcile.Result{Requeue: true}, nil
 		}
 	}
 
@@ -282,23 +281,28 @@ func (r *ReconcileDataset) Reconcile(request reconcile.Request) (reconcile.Resul
 	SecretKey := associatedCephUserSecrets.Data["SecretKey"]
 	InternalEndpoint := associatedRgwService.Spec.ClusterIP
 
+	internalDatasetLabels := make(map[string]string)
+	for key, value := range datasetInstance.ObjectMeta.Labels {
+		internalDatasetLabels[key] = value
+	}
+	internalDatasetLabels["dlf-plugin-type"] = "caching"
+	internalDatasetLabels["dlf-plugin-name"] = "ceph-cache-plugin"
+
 	internalDataset := &comv1alpha1.DatasetInternal{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:  datasetInstance.ObjectMeta.Name,
+			Name:      datasetInstance.ObjectMeta.Name,
 			Namespace: datasetInstance.ObjectMeta.Namespace,
-			Labels: map[string]string{
-				"dlf-plugin-type": "caching",
-				"dlf-plugin-name": "ceph-cache-plugin",
-			},
+			Labels:    internalDatasetLabels,
 		},
 		Spec: comv1alpha1.DatasetSpec{
 			Local: map[string]string{
-				"type": "COS",
+				"type":            "COS",
 				"accessKeyID":     string(AccessKey),
 				"secretAccessKey": string(SecretKey),
-				"endpoint":        "http://"+InternalEndpoint,
+				"endpoint":        "http://" + InternalEndpoint,
 				"bucket":          datasetInstance.Spec.Local["bucket"],
-				"provision": 	   "true", //TODO fix this in S3Mirror radosgw
+				"provision":       datasetInstance.Spec.Local["provision"],
+				"region":          datasetInstance.Spec.Local["region"],
 			},
 		},
 	}
@@ -322,32 +326,32 @@ func (r *ReconcileDataset) Reconcile(request reconcile.Request) (reconcile.Resul
 	return reconcile.Result{}, nil
 }
 
-func populateListOfObjects(c client.Client, listToFill interface{}, options []client.ListOption) error{
+func populateListOfObjects(c client.Client, listToFill interface{}, options []client.ListOption) error {
 
 	listToFillCast, ok := listToFill.(runtime.Object)
 	if !ok {
 		return errors.NewBadRequest("populateListOfObjects wrong interface passed")
 	}
-	err := c.List(context.TODO(),listToFillCast,options...)
-	if(err!=nil){
+	err := c.List(context.TODO(), listToFillCast, options...)
+	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func getExactlyOneObject(c client.Client,instance runtime.Object, name string, namespace string) error{
-	err := c.Get(context.TODO(),types.NamespacedName{
+func getExactlyOneObject(c client.Client, instance runtime.Object, name string, namespace string) error {
+	err := c.Get(context.TODO(), types.NamespacedName{
 		Namespace: namespace,
 		Name:      name,
-	},instance)
+	}, instance)
 	return err
 }
 
-func addErrorToDataset(c client.Client,errorString string,dataset *comv1alpha1.Dataset) error {
+func addErrorToDataset(c client.Client, errorString string, dataset *comv1alpha1.Dataset) error {
 	dataset.Status.Caching.Info = errorString
 	log.WithName("errorToDataset").Info(errorString)
-	err := c.Status().Update(context.TODO(),dataset)
-	if(err!=nil){
+	err := c.Status().Update(context.TODO(), dataset)
+	if err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
DLF with the latest commits can [provision the bucket](https://github.com/IBM/dataset-lifecycle-framework/commit/adf231669a67a0b419f862cac3b5f37467c4ffb4) and remove it as well with [remove-on-delete](https://github.com/IBM/dataset-lifecycle-framework/commit/103f14ae28eeca3b28f0af6c2279b54f4a986d6c). This PR aligns our CEPH caching plugin with the aforementioned features and also propagates properly the ```region``` of the Dataset to the CEPH caching plugin.