### PR TITLE
S3 bucket creation command is missing for archive handler

### DIFF
--- a/src/dataset-operator/pkg/controller/dataset/archive_handler.go
+++ b/src/dataset-operator/pkg/controller/dataset/archive_handler.go
@@ -30,6 +30,7 @@ func getPodDataDownload(dataset *comv1alpha1.Dataset, operatorNamespace string) 
 		command = []string{
 			"/bin/sh", "-c",
 			"wget " + fileUrl + " -P" + " /tmp && " +
+			"aws s3api create-bucket --bucket "+ podId +" --endpoint-url $ENDPOINT && "+
 			"aws s3 cp /tmp/" + fileName +" s3://"+podId+" --endpoint-url $ENDPOINT && "+
 			"rm -rf  /tmp/" + fileName,
 		}

--- a/src/dataset-operator/pkg/controller/dataset/archive_handler.go
+++ b/src/dataset-operator/pkg/controller/dataset/archive_handler.go
@@ -23,6 +23,7 @@ func getPodDataDownload(dataset *comv1alpha1.Dataset, operatorNamespace string) 
 		"wget " + fileUrl + " -P" + " /tmp && " +
 		"tar -xf /tmp/" + fileName + " -C /data/" + podId +" && "+
 		"rm -rf /tmp/" + fileName + " && "+
+		"aws s3api create-bucket --bucket "+ podId +" --endpoint-url $ENDPOINT && "+
 		"aws s3 cp /data/" + podId +" s3://"+podId+" --recursive --endpoint-url $ENDPOINT && "+
 		"rm -rf /data",
 	}


### PR DESCRIPTION
In the newer version of aws command and S3 server, S3 bucket needs to be create with an separate S3 API since the `aws s3 cp` command no longer creates a new bucket. Below are the quick fixes to make it working.

Ideally we should make these commands configurable via a configmap, so when there's new changes to S3 API, we can update the configmap rather than building a new image every time.

