### PR TITLE
fix: use anonymous credentials with goofys

### DIFF
--- a/src/csi-s3/pkg/s3/mounter_goofys.go
+++ b/src/csi-s3/pkg/s3/mounter_goofys.go
@@ -57,7 +57,6 @@ func (goofys *goofysMounter) Mount(source string, target string) error {
 	}
 	args := []string{
 		fmt.Sprintf("--endpoint=%s", goofys.endpoint),
-		fmt.Sprintf("--profile=%s", goofys.volumeID),
 		"--type-cache-ttl","1s",
 		"--stat-cache-ttl","1s",
 		"--dir-mode","0777",
@@ -65,6 +64,9 @@ func (goofys *goofysMounter) Mount(source string, target string) error {
 		"--http-timeout","5m",
 		//fmt.Sprintf("--cheap=%s", os.Getenv("cheap")),
 		"-o", "allow_other",
+	}
+	if goofys.accessKeyID != "" && goofys.secretAccessKey != "" {
+		args = append(args, fmt.Sprintf("--profile=%s", goofys.volumeID))
 	}
 	if goofys.region != "" {
 		args = append(args, "--region", goofys.region)


### PR DESCRIPTION
I am trying to use datashim with a public bucket. And this should work (in theory). 

After digging around I saw that goofys supports this. However contrary to [this commit message](https://github.com/kahing/goofys/commit/bda62d906b8d6dc6499be87705466cb6e2575bf2) it seems that to not use any credentials one can just omit the `--profile` argument and goofys will figure things out.

I tested this change out and things work now if I use empty strings for the credentials (`""`).

closes #131 

For example this manifest will not work before this PR but works after this change:
```
apiVersion: com.ie.ibm.hpsys/v1alpha1
kind: Dataset
metadata:
  name: example-public-dataset
spec:
  local:
    type: "COS"
    accessKeyID: ""
    secretAccessKey: ""
    endpoint: "http://s3.amazonaws.com"
    bucket: "giab"
---
apiVersion: v1
kind: Pod
metadata:
  name: test-pod-tasko
spec:
  containers:
  - name: test
    image: ubuntu
    imagePullPolicy: IfNotPresent
    volumeMounts:
    - mountPath: /data
      name: s3bucket
    command: ["sleep", "99999999"]
  volumes:
  - name: s3bucket
    persistentVolumeClaim:
      claimName: example-public-dataset
```
