### PR TITLE
chore(chart): add option to skip installing CRDs

### DIFF
--- a/src/dataset-operator/chart/templates/crds/com.ie.ibm.hpsys_datasetinternals_crd.yaml
+++ b/src/dataset-operator/chart/templates/crds/com.ie.ibm.hpsys_datasetinternals_crd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installCrds -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -59,3 +60,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end -}}

--- a/src/dataset-operator/chart/templates/crds/com.ie.ibm.hpsys_datasets_crd.yaml
+++ b/src/dataset-operator/chart/templates/crds/com.ie.ibm.hpsys_datasets_crd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installCrds -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -67,3 +68,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end -}}

--- a/src/dataset-operator/chart/values.yaml
+++ b/src/dataset-operator/chart/values.yaml
@@ -2,3 +2,4 @@
 #baseRepo: ""
 #dockerRegistrySecret: ""
 generatekeys: {}
+installCrds: true


### PR DESCRIPTION
I think is useful to be able to skip the installation of the crds if desired.

For example if there are multiple installations of datashim in different namespaces in the same cluster then reinstalling the crds with every installation is not necessary. Also it could be that developers/users who have access to install datashim in the cluster actually do not have permissions to install crds (which are always cluster-wide).

Signed-off-by: Tasko Olevski <tasko.olevski@sdsc.ethz.ch>