### PR TITLE
Update attachment api to support K8s 1.20+

### DIFF
--- a/build-tools/Makefile
+++ b/build-tools/Makefile
@@ -1,12 +1,12 @@
 DOCKER_REGISTRY ?= quay.io/ibm-dlf
 
-ARCH ?=
+ARCH ?= 
 
 #used only when building the plugins
 
-EXTERNAL_ATTACHER_TAG ?= v3.0.0-rc1
-EXTERNAL_PROVISIONER_TAG ?= v2.0.0-rc2
-NODE_DRIVER_REGISTRAR_TAG ?= v1.3.0
+EXTERNAL_ATTACHER_TAG ?= v3.3.0
+EXTERNAL_PROVISIONER_TAG ?= v2.2.2
+NODE_DRIVER_REGISTRAR_TAG ?= v2.3.0
 
 include helpers.mk
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,20 +7,17 @@ global:
 
   sidecars:
     kubeletPath: "/var/lib/kubelet"
-    baseRepo: "quay.io/k8scsi"
+    baseRepo: "k8s.gcr.io/sig-storage"
     images:
       externalAttacher:
         image: "csi-attacher"
-        tag: "v2.2.0"
+        tag: "v3.3.0"
       nodeDriverRegistrar:
         image: "csi-node-driver-registrar"
-        tag: "v1.2.0"
-      clusterDriverRegistrar:
-        image: "csi-cluster-driver-registrar"
-        tag: "v1.0.1"
+        tag: "v2.3.0"
       externalProvisioner:
         image: "csi-provisioner"
-        tag: "v2.0.2"
+        tag: "v2.2.2"
 
 csi-nfs-chart:
 # baseRepo: "anotherrepo"
@@ -45,8 +42,7 @@ csi-h3-chart:
   csih3:
     image: "csi-h3"
     tag: "v1.2.0"
-  sidecars: {} # in case you want to force override regardless of the csi-s3-chart/values.yaml
-
+  sidecars: {} 
 dataset-operator-chart:
   baseRepo: "quay.io/datashim"
 # dockerRegistrySecret: "anothersecret"

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -43,9 +43,9 @@ orchestration and bring contributions on:
 for credentials of the different types of datasources 
 
 ## **Is anyone actually interested in the framework?**
-* **European Bioinformatics Institute** ( https://www.ebi.ac.uk/ ) are running a POC with DLF and Kubeflow on their cloud infrastructure
+* **European Bioinformatics Institute** ( https://www.ebi.ac.uk/ ) are running a POC with Datashim and Kubeflow on their cloud infrastructure
   * [David Yu Yuan](https://github.com/davidyuyuan) actually reached out to us after a CNCF presentation
-* People from **Open Data Hub** ( https://opendatahub.io/ ) are interested in integrating DLF in ODH
+* People from **Open Data Hub** ( https://opendatahub.io/ ) are interested in integrating Datashim in ODH
   * See relevant issue ( https://github.com/IBM/dataset-lifecycle-framework/issues/40 )
 * **Pachyderm's proposal** is actually very close to the Dataset spec we are supporting.
-  * DLF is forked in their repo and is under evaluation in their repo https://github.com/pachyderm/kfdata
+  * Datashim is forked in their repo and is under evaluation in their repo https://github.com/pachyderm/kfdata

--- a/release-tools/manifests/dlf-arm64.yaml
+++ b/release-tools/manifests/dlf-arm64.yaml
@@ -769,7 +769,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0"
           lifecycle:
             preStop:
               exec:
@@ -847,7 +847,7 @@ spec:
       serviceAccountName: csi-s3
       containers:
         - name: driver-registrar
-          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0"
           imagePullPolicy: Always
           args:
             - --v=5
@@ -1020,7 +1020,7 @@ spec:
       serviceAccountName: csi-attacher-nfs
       containers:
         - name: csi-attacher
-          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"
           args:
             - "--v=10"
             - "--csi-address=$(ADDRESS)"
@@ -1074,7 +1074,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"
           imagePullPolicy: Always
           args:
             - --v=5
@@ -1116,7 +1116,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: "quay.io/k8scsi/csi-provisioner:v2.0.2"
+          image: "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"
           imagePullPolicy: Always
           args:
             - -v=5

--- a/release-tools/manifests/dlf-ibm-k8s.yaml
+++ b/release-tools/manifests/dlf-ibm-k8s.yaml
@@ -921,7 +921,7 @@ spec:
           args:
             - --v=5
             - --csi-address=/plugin/csi.sock
-            - --kubelet-registration-path=/var/data/kubelet/plugins/csi-h3/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-h3/csi.sock
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -958,19 +958,19 @@ spec:
             - name: plugin-dir
               mountPath: /plugin
             - name: pods-mount-dir
-              mountPath: /var/data/kubelet/pods
+              mountPath: /var/lib/kubelet/pods
               mountPropagation: "Bidirectional"
       volumes:
         - name: plugin-dir
           hostPath:
-            path: /var/data/kubelet/plugins/csi-h3
+            path: /var/lib/kubelet/plugins/csi-h3
             type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
-            path: /var/data/kubelet/pods
+            path: /var/lib/kubelet/pods
             type: Directory
         - hostPath:
-            path: /var/data/kubelet/plugins_registry
+            path: /var/lib/kubelet/plugins_registry
             type: DirectoryOrCreate
           name: registration-dir
 ---
@@ -998,7 +998,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0"
           lifecycle:
             preStop:
               exec:
@@ -1076,7 +1076,7 @@ spec:
       serviceAccountName: csi-s3
       containers:
         - name: driver-registrar
-          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0"
           imagePullPolicy: Always
           args:
             - --v=5
@@ -1317,7 +1317,7 @@ spec:
       serviceAccountName: csi-attacher-nfs
       containers:
         - name: csi-attacher
-          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"
           args:
             - "--v=10"
             - "--csi-address=$(ADDRESS)"
@@ -1371,7 +1371,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"
           imagePullPolicy: Always
           args:
             - --v=5
@@ -1413,7 +1413,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: "quay.io/k8scsi/csi-provisioner:v2.0.2"
+          image: "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"
           imagePullPolicy: Always
           args:
             - -v=5

--- a/release-tools/manifests/dlf-ibm-oc.yaml
+++ b/release-tools/manifests/dlf-ibm-oc.yaml
@@ -921,7 +921,7 @@ spec:
           args:
             - --v=5
             - --csi-address=/plugin/csi.sock
-            - --kubelet-registration-path=/var/data/kubelet/plugins/csi-h3/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-h3/csi.sock
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -958,19 +958,19 @@ spec:
             - name: plugin-dir
               mountPath: /plugin
             - name: pods-mount-dir
-              mountPath: /var/data/kubelet/pods
+              mountPath: /var/lib/kubelet/pods
               mountPropagation: "Bidirectional"
       volumes:
         - name: plugin-dir
           hostPath:
-            path: /var/data/kubelet/plugins/csi-h3
+            path: /var/lib/kubelet/plugins/csi-h3
             type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
-            path: /var/data/kubelet/pods
+            path: /var/lib/kubelet/pods
             type: Directory
         - hostPath:
-            path: /var/data/kubelet/plugins_registry
+            path: /var/lib/kubelet/plugins_registry
             type: DirectoryOrCreate
           name: registration-dir
 ---
@@ -998,7 +998,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0"
           lifecycle:
             preStop:
               exec:
@@ -1076,7 +1076,7 @@ spec:
       serviceAccountName: csi-s3
       containers:
         - name: driver-registrar
-          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0"
           imagePullPolicy: Always
           args:
             - --v=5
@@ -1317,7 +1317,7 @@ spec:
       serviceAccountName: csi-attacher-nfs
       containers:
         - name: csi-attacher
-          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"
           args:
             - "--v=10"
             - "--csi-address=$(ADDRESS)"
@@ -1371,7 +1371,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"
           imagePullPolicy: Always
           args:
             - --v=5
@@ -1413,7 +1413,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: "quay.io/k8scsi/csi-provisioner:v2.0.2"
+          image: "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"
           imagePullPolicy: Always
           args:
             - -v=5

--- a/release-tools/manifests/dlf-oc.yaml
+++ b/release-tools/manifests/dlf-oc.yaml
@@ -998,7 +998,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0"
           lifecycle:
             preStop:
               exec:
@@ -1076,7 +1076,7 @@ spec:
       serviceAccountName: csi-s3
       containers:
         - name: driver-registrar
-          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0"
           imagePullPolicy: Always
           args:
             - --v=5
@@ -1317,7 +1317,7 @@ spec:
       serviceAccountName: csi-attacher-nfs
       containers:
         - name: csi-attacher
-          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"
           args:
             - "--v=10"
             - "--csi-address=$(ADDRESS)"
@@ -1371,7 +1371,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"
           imagePullPolicy: Always
           args:
             - --v=5
@@ -1413,7 +1413,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: "quay.io/k8scsi/csi-provisioner:v2.0.2"
+          image: "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"
           imagePullPolicy: Always
           args:
             - -v=5

--- a/release-tools/manifests/dlf-ppc64le.yaml
+++ b/release-tools/manifests/dlf-ppc64le.yaml
@@ -769,7 +769,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0"
           lifecycle:
             preStop:
               exec:
@@ -847,7 +847,7 @@ spec:
       serviceAccountName: csi-s3
       containers:
         - name: driver-registrar
-          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0"
           imagePullPolicy: Always
           args:
             - --v=5
@@ -1020,7 +1020,7 @@ spec:
       serviceAccountName: csi-attacher-nfs
       containers:
         - name: csi-attacher
-          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"
           args:
             - "--v=10"
             - "--csi-address=$(ADDRESS)"
@@ -1074,7 +1074,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"
           imagePullPolicy: Always
           args:
             - --v=5
@@ -1116,7 +1116,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: "quay.io/k8scsi/csi-provisioner:v2.0.2"
+          image: "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"
           imagePullPolicy: Always
           args:
             - -v=5

--- a/release-tools/manifests/dlf.yaml
+++ b/release-tools/manifests/dlf.yaml
@@ -998,7 +998,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0"
           lifecycle:
             preStop:
               exec:
@@ -1076,7 +1076,7 @@ spec:
       serviceAccountName: csi-s3
       containers:
         - name: driver-registrar
-          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0"
           imagePullPolicy: Always
           args:
             - --v=5
@@ -1317,7 +1317,7 @@ spec:
       serviceAccountName: csi-attacher-nfs
       containers:
         - name: csi-attacher
-          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"
           args:
             - "--v=10"
             - "--csi-address=$(ADDRESS)"
@@ -1371,7 +1371,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
+          image: "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"
           imagePullPolicy: Always
           args:
             - --v=5
@@ -1413,7 +1413,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: "quay.io/k8scsi/csi-provisioner:v2.0.2"
+          image: "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"
           imagePullPolicy: Always
           args:
             - -v=5

--- a/src/csi-h3/chart/values.yaml
+++ b/src/csi-h3/chart/values.yaml
@@ -1,6 +1,22 @@
 # override from the root values.yaml
 # just for reference, you can emit
-sidecars: {}
+sidecars: 
+  kubeletPath: "/var/lib/kubelet"
+  baseRepo: "quay.io/k8scsi"
+  images:
+    externalAttacher:
+      image: "csi-attacher"
+      tag: "v2.2.0"
+    nodeDriverRegistrar:
+      image: "csi-node-driver-registrar"
+      tag: "v1.2.0"
+    externalProvisioner:
+      image: "csi-provisioner"
+      tag: "v2.0.2"
+    clusterDriverRegistrar:
+      image: "csi-cluster-driver-registrar"
+      tag: "v1.0.1"
+
 csih3: {}
-# baseRepo: "anotherrepo"
+# baseRepo: "quay.io/k8scsi"
 # dockerRegistrySecret: "anothersecret"


### PR DESCRIPTION
This is a breaking change as any K8s cluster that's older than 1.17 will not be supported by Datashim anymore. Fixes #132 and #129 