### PR TITLE
feat(chart): add nodeSelector, tolerations, affinity

### DIFF
--- a/src/csi-driver-nfs/chart/templates/csi-attacher-nfsplugin.yaml
+++ b/src/csi-driver-nfs/chart/templates/csi-attacher-nfsplugin.yaml
@@ -75,3 +75,15 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/src/csi-driver-nfs/chart/templates/csi-attacher-nfsplugin.yaml
+++ b/src/csi-driver-nfs/chart/templates/csi-attacher-nfsplugin.yaml
@@ -75,14 +75,6 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/src/csi-driver-nfs/chart/templates/csi-nodeplugin-nfsplugin.yaml
+++ b/src/csi-driver-nfs/chart/templates/csi-nodeplugin-nfsplugin.yaml
@@ -84,15 +84,7 @@ spec:
             path: {{ $csiNFSProperties.sidecars.kubeletPath }}/plugins_registry
             type: Directory
           name: registration-dir
-      {{- with .Values.plugin.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.plugin.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.plugin.tolerations }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/src/csi-driver-nfs/chart/templates/csi-nodeplugin-nfsplugin.yaml
+++ b/src/csi-driver-nfs/chart/templates/csi-nodeplugin-nfsplugin.yaml
@@ -84,3 +84,15 @@ spec:
             path: {{ $csiNFSProperties.sidecars.kubeletPath }}/plugins_registry
             type: Directory
           name: registration-dir
+      {{- with .Values.plugin.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.plugin.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.plugin.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/src/csi-driver-nfs/chart/values.yaml
+++ b/src/csi-driver-nfs/chart/values.yaml
@@ -4,3 +4,12 @@ sidecars: {}
 csinfs: {}
 # baseRepo: "anotherrepo"
 # dockerRegistrySecret: "anothersecret"
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+plugin:
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/src/csi-driver-nfs/chart/values.yaml
+++ b/src/csi-driver-nfs/chart/values.yaml
@@ -5,11 +5,4 @@ csinfs: {}
 # baseRepo: "anotherrepo"
 # dockerRegistrySecret: "anothersecret"
 
-nodeSelector: {}
 tolerations: []
-affinity: {}
-
-plugin:
-  nodeSelector: {}
-  tolerations: []
-  affinity: {}

--- a/src/csi-h3/chart/templates/csi-controller-h3.yaml
+++ b/src/csi-h3/chart/templates/csi-controller-h3.yaml
@@ -74,14 +74,6 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir:
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/src/csi-h3/chart/templates/csi-controller-h3.yaml
+++ b/src/csi-h3/chart/templates/csi-controller-h3.yaml
@@ -74,3 +74,15 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/src/csi-h3/chart/templates/csi-nodeplugin-h3.yaml
+++ b/src/csi-h3/chart/templates/csi-nodeplugin-h3.yaml
@@ -90,15 +90,7 @@ spec:
             path: {{ $csiH3Properties.sidecars.kubeletPath }}/plugins_registry
             type: DirectoryOrCreate
           name: registration-dir
-      {{- with .Values.plugin.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.plugin.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.plugin.tolerations }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/src/csi-h3/chart/templates/csi-nodeplugin-h3.yaml
+++ b/src/csi-h3/chart/templates/csi-nodeplugin-h3.yaml
@@ -90,3 +90,15 @@ spec:
             path: {{ $csiH3Properties.sidecars.kubeletPath }}/plugins_registry
             type: DirectoryOrCreate
           name: registration-dir
+      {{- with .Values.plugin.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.plugin.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.plugin.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/src/csi-h3/chart/values.yaml
+++ b/src/csi-h3/chart/values.yaml
@@ -5,11 +5,4 @@ csih3: {}
 # baseRepo: "anotherrepo"
 # dockerRegistrySecret: "anothersecret"
 
-nodeSelector: {}
 tolerations: []
-affinity: {}
-
-plugin:
-  nodeSelector: {}
-  tolerations: []
-  affinity: {}

--- a/src/csi-h3/chart/values.yaml
+++ b/src/csi-h3/chart/values.yaml
@@ -4,3 +4,12 @@ sidecars: {}
 csih3: {}
 # baseRepo: "anotherrepo"
 # dockerRegistrySecret: "anothersecret"
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+plugin:
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/src/csi-s3/chart/templates/attacher.yaml
+++ b/src/csi-s3/chart/templates/attacher.yaml
@@ -62,15 +62,7 @@ spec:
             path: {{ $csiS3Properties.sidecars.kubeletPath }}/plugins/csi-s3
             type: DirectoryOrCreate
           name: socket-dir
-      
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/src/csi-s3/chart/templates/attacher.yaml
+++ b/src/csi-s3/chart/templates/attacher.yaml
@@ -62,3 +62,16 @@ spec:
             path: {{ $csiS3Properties.sidecars.kubeletPath }}/plugins/csi-s3
             type: DirectoryOrCreate
           name: socket-dir
+      
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/src/csi-s3/chart/templates/csi-s3.yaml
+++ b/src/csi-s3/chart/templates/csi-s3.yaml
@@ -161,3 +161,16 @@ spec:
             path: /dev
             type: Directory
           name: dev-dir
+
+      {{- with .Values.plugin.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.plugin.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.plugin.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/src/csi-s3/chart/templates/csi-s3.yaml
+++ b/src/csi-s3/chart/templates/csi-s3.yaml
@@ -162,15 +162,7 @@ spec:
             type: Directory
           name: dev-dir
 
-      {{- with .Values.plugin.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.plugin.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.plugin.tolerations }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/src/csi-s3/chart/templates/provisioner.yaml
+++ b/src/csi-s3/chart/templates/provisioner.yaml
@@ -60,14 +60,6 @@ spec:
             path: {{ $csiS3Properties.sidecars.kubeletPath }}/plugins/csi-s3
             type: DirectoryOrCreate
           name: socket-dir
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/src/csi-s3/chart/templates/provisioner.yaml
+++ b/src/csi-s3/chart/templates/provisioner.yaml
@@ -60,3 +60,15 @@ spec:
             path: {{ $csiS3Properties.sidecars.kubeletPath }}/plugins/csi-s3
             type: DirectoryOrCreate
           name: socket-dir
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/src/csi-s3/chart/values.yaml
+++ b/src/csi-s3/chart/values.yaml
@@ -5,3 +5,13 @@ csis3: {}
 # baseRepo: "anotherrepo"
 # dockerRegistrySecret: "anothersecret"
 mounter: "goofys"
+
+attacher:
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+plugin:
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/src/csi-s3/chart/values.yaml
+++ b/src/csi-s3/chart/values.yaml
@@ -6,12 +6,4 @@ csis3: {}
 # dockerRegistrySecret: "anothersecret"
 mounter: "goofys"
 
-attacher:
-  nodeSelector: {}
-  tolerations: []
-  affinity: {}
-
-plugin:
-  nodeSelector: {}
-  tolerations: []
-  affinity: {}
+tolerations: []

--- a/src/dataset-operator/chart/templates/apps/operator.yaml
+++ b/src/dataset-operator/chart/templates/apps/operator.yaml
@@ -66,6 +66,18 @@ spec:
         - name: webhook-tls-certs
           secret:
             secretName: webhook-server-tls
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/src/dataset-operator/chart/values.yaml
+++ b/src/dataset-operator/chart/values.yaml
@@ -2,3 +2,7 @@
 #baseRepo: ""
 #dockerRegistrySecret: ""
 generatekeys: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
I noticed that there does not seem to be an option to add tolerations, affinities, etc.

This is definitely useful when you have nodes with taints but when you want the daemonSets (for node plugins) to run on all of your nodes. I could not find in the current state of the code any way to do this.

So I followed how affinities/tolerations/nodeSelectors are added when you create a helm chart with the helm CLI (i.e. `helm create foo`). Unlike the helm CLI template though I did separate things for the DaemonSets and everything else (i.e. controllers/attachers). For example you may want to run the controller on a specific node but the DaemonSet on all nodes (or on more nodes).

Let me know what you think. I am happy to make adjustments.

Signed-off-by: Tasko Olevski <tasko.olevski@sdsc.ethz.ch>
