### PR TITLE
Fix #157 pvc mounts in init containers using the dataset labels

### DIFF
--- a/src/dataset-operator/pkg/admissioncontroller/mutate.go
+++ b/src/dataset-operator/pkg/admissioncontroller/mutate.go
@@ -105,6 +105,11 @@ func Mutate(body []byte) ([]byte, error) {
 		}
 
 		containers := pod.Spec.Containers
+		// Adding InitContainers to the list of containers that will have mounts mutated
+		if len(pod.Spec.InitContainers) != 0 {
+			log.Printf("Init containers in pod")
+			containers = append(containers, pod.Spec.InitContainers...)
+		}
 		for container_idx, container := range containers {
 			mounts := container.VolumeMounts
 			mount_names := []string{}


### PR DESCRIPTION
ensures that the dataset, mount and configmap labels work across both init and normal containers