### PR TITLE
temporary update to manifests to accommodate old images

### DIFF
--- a/release-tools/manifests/dlf-arm64.yaml
+++ b/release-tools/manifests/dlf-arm64.yaml
@@ -1022,7 +1022,7 @@ spec:
           # Replace this with the built image name
           image: "quay.io/datashim/dataset-operator:latest-arm64"
           command:
-            - /manager
+            - dataset-operator
           imagePullPolicy: Always
           ports:
             - containerPort: 9443

--- a/release-tools/manifests/dlf-ibm-k8s.yaml
+++ b/release-tools/manifests/dlf-ibm-k8s.yaml
@@ -1219,7 +1219,7 @@ spec:
           # Replace this with the built image name
           image: "quay.io/datashim/dataset-operator:latest-amd64"
           command:
-            - /manager
+            - dataset-operator
           imagePullPolicy: Always
           ports:
             - containerPort: 9443

--- a/release-tools/manifests/dlf-ibm-oc.yaml
+++ b/release-tools/manifests/dlf-ibm-oc.yaml
@@ -1022,7 +1022,7 @@ spec:
           # Replace this with the built image name
           image: "quay.io/datashim/dataset-operator:latest-amd64"
           command:
-            - /manager
+            - dataset-operator
           imagePullPolicy: Always
           ports:
             - containerPort: 9443

--- a/release-tools/manifests/dlf-oc.yaml
+++ b/release-tools/manifests/dlf-oc.yaml
@@ -7,29 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "dlf"
 ---
-# Source: dlf-chart/charts/csi-h3-chart/templates/csi-controller-rbac.yaml
-# This YAML file contains RBAC API objects that are necessary to run external
-# CSI attacher for H3 adapter
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: csi-controller-h3
-  labels:
-    app.kubernetes.io/name: "dlf"
-  namespace: dlf
----
-# Source: dlf-chart/charts/csi-h3-chart/templates/csi-nodeplugin-rbac.yaml
-# This YAML defines all API objects to create RBAC roles for CSI node plugin
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: csi-nodeplugin-h3
-  labels:
-    app.kubernetes.io/name: "dlf"
-  namespace: dlf
----
 # Source: dlf-chart/charts/csi-nfs-chart/templates/csi-attacher-rbac.yaml
 # This YAML file contains RBAC API objects that are necessary to run external
 # CSI attacher for nfs flex adapter
@@ -123,15 +100,6 @@ data:
   tls.crt: YmFyCg==
   tls.key: YmFyCg==
 ---
-# Source: dlf-chart/charts/csi-h3-chart/templates/csi-h3-storageclass.yaml
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: h3
-  labels:
-    app.kubernetes.io/name: "dlf"
-provisioner: kubernetes.io/no-provisioner
----
 # Source: dlf-chart/charts/csi-s3-chart/templates/storageclass.yaml
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -162,10 +130,11 @@ parameters:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
   name: datasetsinternal.com.ie.ibm.hpsys
 spec:
-  conversion:
-    strategy: None
   group: com.ie.ibm.hpsys
   names:
     kind: DatasetInternal
@@ -192,43 +161,77 @@ spec:
           metadata:
             type: object
           spec:
-            description: DatasetInternalSpec defines the desired state of DatasetInternal
+            description: DatasetSpec defines the desired state of Dataset
             properties:
+              extract:
+                type: string
+              format:
+                type: string
               local:
                 additionalProperties:
                   type: string
-                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                  Important: Run "operator-sdk generate k8s" to regenerate code after
-                  modifying this file Add custom validation using kubebuilder tags:
-                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                description: Foo is an example field of Dataset. Edit dataset_types.go
+                  to remove/update
                 type: object
-                x-kubernetes-preserve-unknown-fields: true
               remote:
                 additionalProperties:
                   type: string
                 type: object
-                x-kubernetes-preserve-unknown-fields: true
+              type:
+                description: TODO temp definition for archive
+                type: string
+              url:
+                type: string
             type: object
-            x-kubernetes-preserve-unknown-fields: true
           status:
             description: DatasetInternalStatus defines the observed state of DatasetInternal
+            properties:
+              caching:
+                properties:
+                  placements:
+                    properties:
+                      datalocations:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      gateways:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
             type: object
-            x-kubernetes-preserve-unknown-fields: true
         type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
 # Source: dlf-chart/charts/dataset-operator-chart/templates/crds/com.ie.ibm.hpsys_datasets_crd.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
   name: datasets.com.ie.ibm.hpsys
 spec:
-  conversion:
-    strategy: None
   group: com.ie.ibm.hpsys
   names:
     kind: Dataset
@@ -257,100 +260,55 @@ spec:
           spec:
             description: DatasetSpec defines the desired state of Dataset
             properties:
+              extract:
+                type: string
+              format:
+                type: string
               local:
                 additionalProperties:
                   type: string
-                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                  Important: Run "operator-sdk generate k8s" to regenerate code after
-                  modifying this file Add custom validation using kubebuilder tags:
-                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
-                  Conf map[string]string `json:"conf,omitempty"`'
+                description: Foo is an example field of Dataset. Edit dataset_types.go
+                  to remove/update
                 type: object
-                x-kubernetes-preserve-unknown-fields: true
               remote:
                 additionalProperties:
                   type: string
                 type: object
-                x-kubernetes-preserve-unknown-fields: true
+              type:
+                description: TODO temp definition for archive
+                type: string
+              url:
+                type: string
             type: object
-            x-kubernetes-preserve-unknown-fields: true
           status:
             description: DatasetStatus defines the observed state of Dataset
             properties:
-              error:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "operator-sdk generate k8s" to regenerate
-                  code after modifying this file Add custom validation using kubebuilder
-                  tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-                type: string
+              caching:
+                properties:
+                  info:
+                    type: string
+                  status:
+                    type: string
+                type: object
+              provision:
+                properties:
+                  info:
+                    type: string
+                  status:
+                    type: string
+                type: object
             type: object
-            x-kubernetes-preserve-unknown-fields: true
         type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
     subresources:
       status: {}
----
-# Source: dlf-chart/charts/csi-h3-chart/templates/csi-controller-rbac.yaml
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: external-controller-h3
-  labels:
-    app.kubernetes.io/name: "dlf"
-rules:
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["csi.storage.k8s.io"]
-    resources: ["csinodeinfos"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update", "patch"]
----
-# Source: dlf-chart/charts/csi-h3-chart/templates/csi-controller-rbac.yaml
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-cluster-driver-registrar-role-h3
-  labels:
-    app.kubernetes.io/name: "dlf"
-rules:
-  - apiGroups: ["csi.storage.k8s.io"]
-    resources: ["csidrivers"]
-    verbs: ["create", "delete"]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["create", "list", "watch", "delete"]
----
-# Source: dlf-chart/charts/csi-h3-chart/templates/csi-nodeplugin-rbac.yaml
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-nodeplugin-h3
-  labels:
-    app.kubernetes.io/name: "dlf"
-rules:
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: [""]
-    resources: ["secrets","secret"]
-    verbs: ["get", "list"]
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
 # Source: dlf-chart/charts/csi-nfs-chart/templates/csi-attacher-rbac.yaml
 kind: ClusterRole
@@ -554,6 +512,7 @@ rules:
   resources:
   - '*'
   - datasetsinternal
+  - datasets
   verbs:
   - '*'
 - apiGroups:
@@ -577,57 +536,6 @@ rules:
 - apiGroups: ["batch", "extensions"]
   resources: ["jobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
----
-# Source: dlf-chart/charts/csi-h3-chart/templates/csi-controller-rbac.yaml
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-attacher-role-h3
-  labels:
-    app.kubernetes.io/name: "dlf"
-  namespace: dlf
-subjects:
-  - kind: ServiceAccount
-    name: csi-controller-h3
-    namespace: dlf
-roleRef:
-  kind: ClusterRole
-  name: external-controller-h3
-  apiGroup: rbac.authorization.k8s.io
----
-# Source: dlf-chart/charts/csi-h3-chart/templates/csi-controller-rbac.yaml
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-cluster-driver-registrar-binding-h3
-  labels:
-    app.kubernetes.io/name: "dlf"
-  namespace: dlf
-subjects:
-  - kind: ServiceAccount
-    name: csi-controller-h3
-    namespace: dlf
-roleRef:
-  kind: ClusterRole
-  name: csi-cluster-driver-registrar-role-h3
-  apiGroup: rbac.authorization.k8s.io
----
-# Source: dlf-chart/charts/csi-h3-chart/templates/csi-nodeplugin-rbac.yaml
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-nodeplugin-h3
-  labels:
-    app.kubernetes.io/name: "dlf"
-  namespace: dlf
-subjects:
-  - kind: ServiceAccount
-    name: csi-nodeplugin-h3
-    namespace: dlf
-roleRef:
-  kind: ClusterRole
-  name: csi-nodeplugin-h3
-  apiGroup: rbac.authorization.k8s.io
 ---
 # Source: dlf-chart/charts/csi-nfs-chart/templates/csi-attacher-rbac.yaml
 kind: ClusterRoleBinding
@@ -882,97 +790,12 @@ metadata:
     app.kubernetes.io/name: "dlf"
   namespace: dlf
 spec:
-  selector:
-    name: dataset-operator
   ports:
     - port: 443
+      protocol: TCP
       targetPort: webhook-api
----
-# Source: dlf-chart/charts/csi-h3-chart/templates/csi-nodeplugin-h3.yaml
-# This YAML file contains driver-registrar & csi driver nodeplugin API objects
-# that are necessary to run CSI nodeplugin for H3
-kind: DaemonSet
-apiVersion: apps/v1
-metadata:
-  name: csi-nodeplugin-h3
-  labels:
-    app.kubernetes.io/name: "dlf"
-  namespace: dlf
-spec:
   selector:
-    matchLabels:
-      app: csi-nodeplugin-h3
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: "dlf"
-        app: csi-nodeplugin-h3
-    spec:
-      serviceAccountName: csi-nodeplugin-h3
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
-      containers:
-        - name: node-driver-registrar
-          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi-h3 /registration/csi-h3-reg.sock"]
-          args:
-            - --v=5
-            - --csi-address=/plugin/csi.sock
-            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-h3/csi.sock
-          env:
-            - name: KUBE_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-          volumeMounts:
-            - name: plugin-dir
-              mountPath: /plugin
-            - name: registration-dir
-              mountPath: /registration
-        - name: h3
-          securityContext:
-            privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
-            allowPrivilegeEscalation: true
-          image: "carvicsforth/csi-h3:v1.2.0"
-          args:
-            - "--nodeid=$(NODE_ID)"
-            - "--endpoint=$(CSI_ENDPOINT)"
-          env:
-            - name: NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: CSI_ENDPOINT
-              value: unix://plugin/csi.sock
-          # imagePullPolicy: "Always"
-          lifecycle:
-            postStart:
-              exec:
-                command: ["/bin/sh", "-c", "mount -t fuse.h3fuse | while read -r mount; do umount $(echo $mount | awk '{print $3}') ; done"]
-          volumeMounts:
-            - name: plugin-dir
-              mountPath: /plugin
-            - name: pods-mount-dir
-              mountPath: /var/lib/kubelet/pods
-              mountPropagation: "Bidirectional"
-      volumes:
-        - name: plugin-dir
-          hostPath:
-            path: /var/lib/kubelet/plugins/csi-h3
-            type: DirectoryOrCreate
-        - name: pods-mount-dir
-          hostPath:
-            path: /var/lib/kubelet/pods
-            type: Directory
-        - hostPath:
-            path: /var/lib/kubelet/plugins_registry
-            type: DirectoryOrCreate
-          name: registration-dir
+    name: dataset-operator
 ---
 # Source: dlf-chart/charts/csi-nfs-chart/templates/csi-nodeplugin-nfsplugin.yaml
 # This YAML file contains driver-registrar & csi driver nodeplugin API objects
@@ -1202,7 +1025,7 @@ spec:
             - dataset-operator
           imagePullPolicy: Always
           ports:
-            - containerPort: 8443
+            - containerPort: 9443
               name: webhook-api
           env:
             - name: WATCH_NAMESPACE
@@ -1219,80 +1042,12 @@ spec:
                   fieldPath: metadata.namespace
           volumeMounts:
             - name: webhook-tls-certs
-              mountPath: /run/secrets/tls
+              mountPath: /tmp/k8s-webhook-server/serving-certs
               readOnly: true
       volumes:
         - name: webhook-tls-certs
           secret:
             secretName: webhook-server-tls
----
-# Source: dlf-chart/charts/csi-h3-chart/templates/csi-controller-h3.yaml
-# This YAML file contains attacher & csi driver API objects that are necessary
-# to run external CSI attacher for H3
-kind: StatefulSet
-apiVersion: apps/v1
-metadata:
-  name: csi-controller-h3
-  labels:
-    app.kubernetes.io/name: "dlf"
-  namespace: dlf
-spec:
-  serviceName: "csi-controller-h3"
-  replicas: 1
-  selector:
-    matchLabels:
-      app: csi-controller-h3
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: "dlf"
-        app: csi-controller-h3
-    spec:
-      serviceAccountName: csi-controller-h3
-      containers:
-        - name: csi-attacher
-          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
-          args:
-            - "--v=5"
-            - "--csi-address=$(ADDRESS)"
-          env:
-            - name: ADDRESS
-              value: /csi/csi.sock
-          # imagePullPolicy: "Always"
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
-        - name: csi-cluster-driver-registrar
-          image: "quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1"
-          args:
-            - "--v=5"
-            - "--pod-info-mount-version=\"v1\""
-            - "--csi-address=$(ADDRESS)"
-          env:
-            - name: ADDRESS
-              value: /csi/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
-        - name: h3
-          image: "carvicsforth/csi-h3:v1.2.0"
-          args :
-            - "--nodeid=$(NODE_ID)"
-            - "--endpoint=$(CSI_ENDPOINT)"
-          env:
-            - name: NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: CSI_ENDPOINT
-              value: unix://plugin/csi.sock
-          # imagePullPolicy: "Always"
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /plugin
-      volumes:
-        - name: socket-dir
-          emptyDir:
 ---
 # Source: dlf-chart/charts/csi-nfs-chart/templates/csi-attacher-nfsplugin.yaml
 kind: StatefulSet

--- a/release-tools/manifests/dlf-ppc64le.yaml
+++ b/release-tools/manifests/dlf-ppc64le.yaml
@@ -1022,7 +1022,7 @@ spec:
           # Replace this with the built image name
           image: "quay.io/datashim/dataset-operator:latest-ppc64le"
           command:
-            - /manager
+            - dataset-operator
           imagePullPolicy: Always
           ports:
             - containerPort: 9443

--- a/release-tools/manifests/dlf.yaml
+++ b/release-tools/manifests/dlf.yaml
@@ -1022,7 +1022,7 @@ spec:
           # Replace this with the built image name
           image: "quay.io/datashim/dataset-operator:latest-amd64"
           command:
-            - /manager
+            - dataset-operator
           imagePullPolicy: Always
           ports:
             - containerPort: 9443

--- a/src/dataset-operator/chart/templates/apps/operator.yaml
+++ b/src/dataset-operator/chart/templates/apps/operator.yaml
@@ -40,7 +40,7 @@ spec:
           image: "{{ .baseRepo }}/{{ .datasetoperator.image }}:{{ .datasetoperator.tag }}-{{ .arch }}"
           {{- end}}
           command:
-            - /manager
+            - dataset-operator
           imagePullPolicy: Always
           ports:
             - containerPort: 9443


### PR DESCRIPTION
This PR restores the previous dataset-operator binary in the manifests, so that the installation process does not create a dataset-operator failing because of the wrong command

Signed-off-by: Srikumar Venugopal <srikumarv@ie.ibm.com>