### PR TITLE
Adds priorityClassName and cluster autoscaler daemonset eviction to charts

### DIFF
--- a/src/csi-driver-nfs/chart/templates/csi-attacher-nfsplugin.yaml
+++ b/src/csi-driver-nfs/chart/templates/csi-attacher-nfsplugin.yaml
@@ -36,6 +36,9 @@ spec:
         {{- include "common.labels" . | nindent 8 }}
         app: csi-attacher-nfsplugin
     spec:
+      {{- if or (.Values.priorityClassName) (.Values.global.priorityClassName) }}
+      priorityClassName: {{ .Values.priorityClassName | default .Values.global.priorityClassName }}
+      {{- end }}
       serviceAccountName: csi-attacher-nfs
       {{- if or (.Values.dockerRegistrySecret) (.Values.global.dockerRegistrySecret) }}
       imagePullSecrets:

--- a/src/csi-driver-nfs/chart/templates/csi-nodeplugin-nfsplugin.yaml
+++ b/src/csi-driver-nfs/chart/templates/csi-nodeplugin-nfsplugin.yaml
@@ -18,6 +18,9 @@ spec:
         {{- include "common.labels" . | nindent 8 }}
         app: csi-nodeplugin-nfsplugin
     spec:
+      {{- if or (.Values.priorityClassName) (.Values.global.priorityClassName) }}
+      priorityClassName: {{ .Values.priorityClassName | default .Values.global.priorityClassName }}
+      {{- end }}
       {{- if or (.Values.dockerRegistrySecret) (.Values.global.dockerRegistrySecret) }}
       imagePullSecrets:
         - name: {{ .Values.dockerRegistrySecret | default .Values.global.dockerRegistrySecret }}

--- a/src/csi-driver-nfs/chart/templates/csi-nodeplugin-nfsplugin.yaml
+++ b/src/csi-driver-nfs/chart/templates/csi-nodeplugin-nfsplugin.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         {{- include "common.labels" . | nindent 8 }}
         app: csi-nodeplugin-nfsplugin
+      {{- if or (hasKey .Values "clusterAutoscalerDSEviction") (hasKey .Values.global "clusterAutoscalerDSEviction") }}
+      annotations:
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: {{ .Values.clusterAutoscalerDSEviction | default .Values.global.clusterAutoscalerDSEviction | quote }}
+      {{- end}}
     spec:
       {{- if or (.Values.priorityClassName) (.Values.global.priorityClassName) }}
       priorityClassName: {{ .Values.priorityClassName | default .Values.global.priorityClassName }}

--- a/src/csi-h3/chart/templates/csi-controller-h3.yaml
+++ b/src/csi-h3/chart/templates/csi-controller-h3.yaml
@@ -21,6 +21,9 @@ spec:
         {{- include "common.labels" . | nindent 8 }}
         app: csi-controller-h3
     spec:
+      {{- if or (.Values.priorityClassName) (.Values.global.priorityClassName) }}
+      priorityClassName: {{ .Values.priorityClassName | default .Values.global.priorityClassName }}
+      {{- end }}
       serviceAccountName: csi-controller-h3
       {{- if or (.Values.dockerRegistrySecret) (.Values.global.dockerRegistrySecret) }}
       imagePullSecrets:

--- a/src/csi-h3/chart/templates/csi-nodeplugin-h3.yaml
+++ b/src/csi-h3/chart/templates/csi-nodeplugin-h3.yaml
@@ -19,6 +19,9 @@ spec:
         {{- include "common.labels" . | nindent 8 }}
         app: csi-nodeplugin-h3
     spec:
+      {{- if or (.Values.priorityClassName) (.Values.global.priorityClassName) }}
+      priorityClassName: {{ .Values.priorityClassName | default .Values.global.priorityClassName }}
+      {{- end }}
       {{- if or (.Values.dockerRegistrySecret) (.Values.global.dockerRegistrySecret) }}
       imagePullSecrets:
         - name: {{ .Values.dockerRegistrySecret | default .Values.global.dockerRegistrySecret }}

--- a/src/csi-h3/chart/templates/csi-nodeplugin-h3.yaml
+++ b/src/csi-h3/chart/templates/csi-nodeplugin-h3.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         {{- include "common.labels" . | nindent 8 }}
         app: csi-nodeplugin-h3
+      {{- if or (hasKey .Values "clusterAutoscalerDSEviction") (hasKey .Values.global "clusterAutoscalerDSEviction") }}
+      annotations:
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: {{ .Values.clusterAutoscalerDSEviction | default .Values.global.clusterAutoscalerDSEviction | quote }}
+      {{- end}}
     spec:
       {{- if or (.Values.priorityClassName) (.Values.global.priorityClassName) }}
       priorityClassName: {{ .Values.priorityClassName | default .Values.global.priorityClassName }}

--- a/src/csi-s3/chart/templates/attacher.yaml
+++ b/src/csi-s3/chart/templates/attacher.yaml
@@ -34,6 +34,9 @@ spec:
         {{- include "common.labels" . | nindent 8 }}
         app: csi-attacher-s3
     spec:
+      {{- if or (.Values.priorityClassName) (.Values.global.priorityClassName) }}
+      priorityClassName: {{ .Values.priorityClassName | default .Values.global.priorityClassName }}
+      {{- end }}
       serviceAccountName: csi-attacher
       {{- if or (.Values.dockerRegistrySecret) (.Values.global.dockerRegistrySecret) }}
       imagePullSecrets:

--- a/src/csi-s3/chart/templates/csi-s3.yaml
+++ b/src/csi-s3/chart/templates/csi-s3.yaml
@@ -64,6 +64,9 @@ spec:
         {{- include "common.labels" . | nindent 8 }}
         app: csi-s3
     spec:
+      {{- if or (.Values.priorityClassName) (.Values.global.priorityClassName) }}
+      priorityClassName: {{ .Values.priorityClassName | default .Values.global.priorityClassName }}
+      {{- end }}
       serviceAccountName: csi-s3
       {{- if or (.Values.dockerRegistrySecret) (.Values.global.dockerRegistrySecret) }}
       imagePullSecrets:

--- a/src/csi-s3/chart/templates/csi-s3.yaml
+++ b/src/csi-s3/chart/templates/csi-s3.yaml
@@ -63,6 +63,10 @@ spec:
       labels:
         {{- include "common.labels" . | nindent 8 }}
         app: csi-s3
+      {{- if or (hasKey .Values "clusterAutoscalerDSEviction") (hasKey .Values.global "clusterAutoscalerDSEviction") }}
+      annotations:
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: {{ .Values.clusterAutoscalerDSEviction | default .Values.global.clusterAutoscalerDSEviction | quote }}
+      {{- end}}
     spec:
       {{- if or (.Values.priorityClassName) (.Values.global.priorityClassName) }}
       priorityClassName: {{ .Values.priorityClassName | default .Values.global.priorityClassName }}

--- a/src/csi-s3/chart/templates/provisioner.yaml
+++ b/src/csi-s3/chart/templates/provisioner.yaml
@@ -32,6 +32,9 @@ spec:
       labels:
         app: csi-provisioner-s3
     spec:
+      {{- if or (.Values.priorityClassName) (.Values.global.priorityClassName) }}
+      priorityClassName: {{ .Values.priorityClassName | default .Values.global.priorityClassName }}
+      {{- end }}
       serviceAccountName: csi-provisioner
       {{- if or (.Values.dockerRegistrySecret) (.Values.global.dockerRegistrySecret) }}
       imagePullSecrets:

--- a/src/dataset-operator/chart/templates/apps/operator.yaml
+++ b/src/dataset-operator/chart/templates/apps/operator.yaml
@@ -19,6 +19,9 @@ spec:
         name: dataset-operator
         {{- include "common.labels" . | nindent 8 }}
     spec:
+      {{- if or (.Values.priorityClassName) (.Values.global.priorityClassName) }}
+      priorityClassName: {{ .Values.priorityClassName | default .Values.global.priorityClassName }}
+      {{- end }}
       serviceAccountName: dataset-operator
       {{- if or (.Values.dockerRegistrySecret) (.Values.global.dockerRegistrySecret) }}
       imagePullSecrets:


### PR DESCRIPTION
This PR adds:
- a way to specify `priorityClassName` (either per plugin or globally)
- a way to configure [Cluster Autoscaler DaemonSet eviction setting](https://github.com/kubernetes/autoscaler/blob/5d3ad0c/cluster-autoscaler/FAQ.md#how-can-i-enabledisable-eviction-for-a-specific-daemonset) (either per plugin or globally)

Both of these configs can help to prevent Kubernetes or Cluster Autoscaler from evicting Datashim plugins pods before workload pods that may rely on it to work properly.