### PR TITLE
ci: import built images in KinD cluster to avoid pulling remotes

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,10 +19,10 @@ jobs:
         run: "sed -i 's/Always/IfNotPresent/g' release-tools/manifests/dlf.yaml"
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.4.0
-      - name: Import built images in Kind Cluster
+      - name: Import built images in KinD Cluster
         run: |
-          kind load docker-image quay.io/datashim-io/dataset-operator:latest
-          kind load docker-image quay.io/datashim-io/generate-keys:latest
+          kind load docker-image -n chart-testing quay.io/datashim-io/dataset-operator:latest
+          kind load docker-image -n chart-testing quay.io/datashim-io/generate-keys:latest
       - name: Install Datashim
         run: make deployment
       - name: Install NooBaa

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,9 +16,13 @@ jobs:
       - name: Make Datashim manifests
         run: make manifests
       - name: Update manifests to use local images
-        run: "sed -i 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' release-tools/manifests/dlf.yaml"
+        run: "sed -i 's/Always/IfNotPresent/g' release-tools/manifests/dlf.yaml"
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.4.0
+      - name: Import built images in Kind Cluster
+        run: |
+          kind load docker-image quay.io/datashim-io/dataset-operator:latest
+          kind load docker-image quay.io/datashim-io/generate-keys:latest
       - name: Install Datashim
         run: make deployment
       - name: Install NooBaa


### PR DESCRIPTION
Fixes #227 

To test this PR we can run the following after having built the images for the `dataset-operator` and `generate-keys`:

```bash
kind create cluster
# ensure we never pull images
sed -i 's/Always/Never/g' release-tools/manifests/dlf.yaml
# import the images
kind load docker-image quay.io/datashim-io/dataset-operator:latest
kind load docker-image quay.io/datashim-io/generate-keys:latest
make deployment
```

The results will be:

```text
oc get pods -n dlf
NAME                                READY   STATUS              RESTARTS   AGE
csi-attacher-nfsplugin-0            0/2     ErrImageNeverPull   0          8s
csi-attacher-s3-0                   0/1     ErrImageNeverPull   0          8s
csi-nodeplugin-nfsplugin-m5qtd      1/2     ErrImageNeverPull   0          8s
csi-provisioner-s3-0                0/1     ErrImageNeverPull   0          8s
csi-s3-zmxqm                        0/2     ErrImageNeverPull   0          8s
dataset-operator-788b4858bc-mrm48   1/1     Running             0          8s
```