### PR TITLE
ci: Setup pre-requisites before installing Datashim

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,3 +1,4 @@
+----
 name: Test on KinD
 on:
   pull_request:
@@ -19,12 +20,6 @@ jobs:
         run: "sed -i 's/Always/IfNotPresent/g' release-tools/manifests/dlf.yaml"
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.4.0
-      - name: Import built images in KinD Cluster
-        run: |
-          kind load docker-image -n chart-testing quay.io/datashim-io/dataset-operator:latest
-          kind load docker-image -n chart-testing quay.io/datashim-io/generate-keys:latest
-      - name: Install Datashim
-        run: make deployment
       - name: Install and configure MinIO
         run: |
           kubectl create -f ci/minio.yaml
@@ -36,6 +31,12 @@ jobs:
          kubectl create secret generic s3-secret \
           --from-literal=accessKeyID=ACCESS_KEY \
           --from-literal=secretAccessKey=SECRET_KEY
+      - name: Import built images in KinD Cluster
+        run: |
+          kind load docker-image -n chart-testing quay.io/datashim-io/dataset-operator:latest
+          kind load docker-image -n chart-testing quay.io/datashim-io/generate-keys:latest
+      - name: Install Datashim
+        run: make deployment
       - name: Create sample Dataset
         run: |
           cat <<EOF | kubectl apply -f -


### PR DESCRIPTION
this change sets up the S3 backend storage (currently, MinIO) before installing Datashim in the CI script