### PR TITLE
feat: support multiple useas modes

### DIFF
--- a/examples/templates/example-pod-mult-useas.yaml
+++ b/examples/templates/example-pod-mult-useas.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    dataset.0.id: "example-dataset"
+    dataset.0.useas: "mount.configmap"
+spec:
+  containers:
+    - name: nginx
+      image: nginx
+      volumeMounts:
+        - mountPath: "/mount/dataset1" #optional, if not specified it would be mounted in /mnt/datasets/example-dataset
+          name: "example-dataset"

--- a/src/dataset-operator/admissioncontroller/mutatingwebhook_test.go
+++ b/src/dataset-operator/admissioncontroller/mutatingwebhook_test.go
@@ -208,4 +208,36 @@ var _ = DescribeTable("Pod is mutated correctly",
 			return patchArray
 		},
 	}),
+	Entry("Pod with no dataset volumes, 1 dataset label, useas mount, configmap -> 1 mount, 1 configmap for same dataset", &testPodLabels{
+		makeInputPodSpec: func() *corev1.Pod {
+			inputPod := testing.MakePod("test-1", "test").
+				AddLabelToPodMetadata("dataset.0.id", "testds").
+				AddLabelToPodMetadata("dataset.0.useas", "mount.configmap").
+				AddContainerToPod(testing.MakeContainer("foo").
+					Obj()).
+				Obj()
+			return &inputPod
+		},
+		makeOutputPatchOperations: func() []jsonpatch.JsonPatchOperation {
+			patchArray := []jsonpatch.JsonPatchOperation{
+				testing.MakeJSONPatchOperation().
+					SetOperation("add").
+					SetVolumeasPath(0).
+					SetPVCasValue("testds").
+					Obj(),
+				testing.MakeJSONPatchOperation().
+					SetOperation("add").
+					SetVolumeMountasPath("containers", 0, 0).
+					SetVolumeMountasValue("testds").
+					Obj(),
+				testing.MakeJSONPatchOperation().
+					SetOperation("add").
+					SetNewConfigMapRefasPath("containers", 0).
+					AddConfigMapRefsToValue([]string{"testds"}).
+					AddSecretRefsToValue([]string{"testds"}).
+					Obj(),
+			}
+			return patchArray
+		},
+	}),
 )


### PR DESCRIPTION
Fixes #271

BY merging this PR, the following pod definition
```
apiVersion: v1
kind: Pod
metadata:
  name: busybox
  labels:
    app: busybox
    dataset.0.id: "tests3a"
    dataset.0.useas: "mount.configmap"
```
will lead to a pod definition like below:
```
apiVersion: v1
kind: Pod
metadata:
...
spec:
  containers:
...
    envFrom:
    - configMapRef:
        name: tests3a
      prefix: tests3a_
    - prefix: tests3a_
      secretRef:
        name: tests3a
...
    volumeMounts:
...
    - mountPath: /mnt/datasets/tests3a
      name: tests3a
...
  volumes:
...
  - name: tests3a
    persistentVolumeClaim:
      claimName: tests3a
```