### PR TITLE
Block webhook from mutating on pod updates

### DIFF
--- a/src/dataset-operator/admissioncontroller/mutatingwebhook_test.go
+++ b/src/dataset-operator/admissioncontroller/mutatingwebhook_test.go
@@ -240,4 +240,35 @@ var _ = DescribeTable("Pod is mutated correctly",
 			return patchArray
 		},
 	}),
+	Entry("Pod with no dataset volumes, 1 dataset label, useas configmap, label present in envFrom -> no patch", &testPodLabels{
+		makeInputPodSpec: func() *corev1.Pod {
+			inputPod := testing.MakePod("test-1", "test").
+				AddLabelToPodMetadata("dataset.0.id", "testds").
+				AddLabelToPodMetadata("dataset.0.useas", "configmap").
+				AddContainerToPod(testing.MakeContainer("foo").
+					AddEnvFromConfigToContainer("testds").
+					Obj()).
+				Obj()
+			return &inputPod
+		},
+		makeOutputPatchOperations: func() []jsonpatch.JsonPatchOperation {
+			return []jsonpatch.JsonPatchOperation{}
+		},
+	}),
+
+	Entry("Pod with no dataset volumes, 1 dataset label, useas configmap, label present in envFrom Secret -> no patch", &testPodLabels{
+		makeInputPodSpec: func() *corev1.Pod {
+			inputPod := testing.MakePod("test-1", "test").
+				AddLabelToPodMetadata("dataset.0.id", "testds").
+				AddLabelToPodMetadata("dataset.0.useas", "configmap").
+				AddContainerToPod(testing.MakeContainer("foo").
+					AddEnvFromSecretToContainer("testds").
+					Obj()).
+				Obj()
+			return &inputPod
+		},
+		makeOutputPatchOperations: func() []jsonpatch.JsonPatchOperation {
+			return []jsonpatch.JsonPatchOperation{}
+		},
+	}),
 )

--- a/src/dataset-operator/testing/wrapper.go
+++ b/src/dataset-operator/testing/wrapper.go
@@ -34,6 +34,33 @@ func (c *ContainerWrapper) AddVolumeMount(mountPath, name string) *ContainerWrap
 	return c
 }
 
+func (c *ContainerWrapper) AddEnvFromConfigToContainer(source string) *ContainerWrapper {
+	c.EnvFrom = append(c.EnvFrom, corev1.EnvFromSource{
+		Prefix: source + "_",
+		ConfigMapRef: &corev1.ConfigMapEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: source,
+			},
+		},
+	})
+
+	return c
+}
+
+func (c *ContainerWrapper) AddEnvFromSecretToContainer(source string) *ContainerWrapper {
+	c.EnvFrom = append(c.EnvFrom, corev1.EnvFromSource{
+		Prefix: source + "_",
+		SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: source,
+			},
+			Optional: new(bool),
+		},
+	})
+
+	return c
+}
+
 func (c *ContainerWrapper) Obj() corev1.Container {
 	return c.Container
 }

--- a/src/generate-keys/webhook.yaml.template
+++ b/src/generate-keys/webhook.yaml.template
@@ -16,7 +16,7 @@ webhooks:
       path: "/mutate-v1-pod"
     caBundle: ${CA_PEM_B64}
   rules:
-  - operations: [ "CREATE", "UPDATE" ]
+  - operations: [ "CREATE" ]
     apiGroups: [""]
     apiVersions: ["v1"]
     resources: ["pods"]


### PR DESCRIPTION
Fixes #287

This PR fixes the issue raised in #287 by:
1. Updating the webhook configuration to only apply to delete
2. Adding extra checks to NOT issue patches for `useas: configmap` if the dataset duplicates the name of an existing configmap

tested with `kubectl edit` on `spec.image` for an existing pod with a dataset injected as a `configmap` and has no issues