### PR TITLE
fix: Ensure S3 buckets are mounted with the right access permissions

### DIFF
--- a/src/dataset-operator/controllers/datasetinternal_controller.go
+++ b/src/dataset-operator/controllers/datasetinternal_controller.go
@@ -464,6 +464,13 @@ func processLocalDatasetCOS(cr *datasets.DatasetInternal, rc *DatasetInternalRec
 
 	storageClassName := "csi-s3"
 
+	var axs corev1.PersistentVolumeAccessMode
+	if readonly == "true" {
+		axs = corev1.ReadOnlyMany
+	} else {
+		axs = corev1.ReadWriteMany
+	}
+
 	newPVC := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
@@ -471,7 +478,7 @@ func processLocalDatasetCOS(cr *datasets.DatasetInternal, rc *DatasetInternalRec
 			Labels:    labels,
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
-			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+			AccessModes: []corev1.PersistentVolumeAccessMode{axs},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceStorage: resource.MustParse("5Gi"),

--- a/src/dataset-operator/go.mod
+++ b/src/dataset-operator/go.mod
@@ -89,3 +89,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/datashim-io/datashim/src/dataset-operator => ../dataset-operator
+
+replace github.com/datashim-io/datashim/plugins/ceph-cache-plugin => ../../plugins/ceph-cache-plugin


### PR DESCRIPTION
Fixes #269 

Ensures that `readonly: true` in Dataset specification is carried through to the mounting of buckets inside the container

Note: this is tested for `csi-s3` backend only. We will need to check other CSI backends to see if the spec is being followed