### PR TITLE
feat: Action for automatic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: release
+
+env:
+  ACTIONS_STEP_DEBUG: true
+
+on:
+  push:
+    tags:
+      - '**'
+jobs:
+  package:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Datashim
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Generate short SHA
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" 
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v2
+        with: 
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and push Dataset operator image
+        run: |
+          cd src/dataset-operator
+          ./build_and_push_multiarch_dataset_operator.sh ${{ vars.REGISTRY_URL }} ${{ github.ref_name }}
+      - name: Build and push Generate Keys image 
+        run: |
+          cd src/generate-keys
+          ./build_and_push_multiarch_generate_keys.sh ${{ vars.REGISTRY_URL }} ${{ github.ref_name }}
+      
+#      - name: Build and push bundled CSI plugins
+#        run: |
+#          cd build-tools
+#          make ARCH=amd64 COMMON_IMAGE_TAG=${{ steps.vars.outputs.sha_short }} build-csi-plugins
+#          make ARCH=amd64 COMMON_IMAGE_TAG=${{ steps.vars.outputs.sha_short }} push-csi-plugins
+#          make ARCH=arm64 COMMON_IMAGE_TAG=${{ steps.vars.outputs.sha_short }} build-csi-plugins
+#          make ARCH=arm64 COMMON_IMAGE_TAG=${{ steps.vars.outputs.sha_short }} push-csi-plugins
+#          make ARCH=ppc64le COMMON_IMAGE_TAG=${{ steps.vars.outputs.sha_short }} build-csi-plugins 
+#          make ARCH=ppc64le COMMON_IMAGE_TAG=${{ steps.vars.outputs.sha_short }} push-csi-plugins 
+#          make COMMON_IMAGE_TAG=${{ steps.vars.outputs.sha_short }}  push-multiarch-csi-plugins
+#
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+      
+      - name: Modify Helm values
+        uses: mikefarah/yq@master
+        with: 
+          cmd: yq --inplace '
+                    with (.dataset-operator-chart.datasetoperator.tag;
+                        . = "${{ github.ref_name }}" ) |
+                    with (.dataset-operator-chart.generatekeys.tag;
+                        . = "${{ github.ref_name }}" ) | 
+                    with (.csi-s3-chart.csis3.tag;
+                        . = "${{ steps.vars.outputs.sha_short }}" ) |
+                    with (.csi-nfs-chart.csinfs.tag;
+                        . = "${{ steps.vars.outputs.sha_short }}" ) ' chart/values.yaml
+
+      - name: Create Helm package
+        run: |
+          cd chart
+          helm package --version ${{ github.ref_name }} -u -d ../.cr-release-packages
+
+      - name: Run chart releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          charts_dir: chart
+          skip_packaging: true
+      
+      - name: Create a release
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          draft: true
+          prerelease: true
+          automatic_release_tag: "${{ github.ref_name }}"
+          
+          
+        
+        
+          

--- a/build-tools/Makefile
+++ b/build-tools/Makefile
@@ -39,8 +39,10 @@ push-csi-plugins:
 	docker push $(CSI_S3_IMAGE)-$(ARCH) ;\
 	docker push $(CSI_NFS_IMAGE)-$(ARCH)
 
-push-multiarch:
+push-multiarch-core:
 	$(call generate_push_multi_arch_manifest,$(DATASET_OPERATOR_IMAGE))
 	$(call generate_push_multi_arch_manifest,$(GENERATE_KEYS_IMAGE))
+
+push-multiarch-csi-plugins:
 	$(call generate_push_multi_arch_manifest,$(CSI_S3_IMAGE))
 	$(call generate_push_multi_arch_manifest,$(CSI_NFS_IMAGE))

--- a/build-tools/helpers.mk
+++ b/build-tools/helpers.mk
@@ -68,7 +68,7 @@ endef
 define generate_push_multi_arch_manifest
 	@export DOCKER_CLI_EXPERIMENTAL=enabled ;\
 	echo "generating multiarch for"+$(1) ;\
-	docker login -u=${DOCKER_USER} -p=${DOCKER_PASSWORD} quay.io ;\
+	docker login -u=${DOCKER_USER} -p=${DOCKER_PASSWORD} ${DOCKER_REGISTRY} ;\
 	docker manifest create $(1) $(1)-amd64 $(1)-arm64 $(1)-ppc64le ;\
 	docker manifest annotate $(1) $(1)-amd64 --arch amd64 ;\
 	docker manifest annotate $(1) $(1)-arm64 --arch arm64 ;\

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,9 +15,6 @@ dependencies:
   - name: csi-s3-chart
     version: 0.1.0
     condition: csi-s3-chart.enabled
-  - name: csi-h3-chart
-    version: 0.1.0
-    condition: csi-h3-chart.enabled
   - name: dataset-operator-chart
     version: 0.1.0
     condition: dataset-operator-chart.enabled

--- a/src/dataset-operator/build_and_push_multiarch_dataset_operator.sh
+++ b/src/dataset-operator/build_and_push_multiarch_dataset_operator.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 REGISTRY_URL="${1:-quay.io/datashim-io}"
-docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le --push -t ${REGISTRY_URL}/dataset-operator .
+VERSION="${2:-latest}"
+docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le --push -t ${REGISTRY_URL}/dataset-operator:${VERSION} .

--- a/src/dataset-operator/build_dataset_operator.sh
+++ b/src/dataset-operator/build_dataset_operator.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 REGISTRY_URL="${1:-quay.io/datashim-io}"
-docker build -t ${REGISTRY_URL}/dataset-operator .
+VERSION="${2:-latest}"
+docker build -t ${REGISTRY_URL}/dataset-operator:${VERSION} .

--- a/src/dataset-operator/go.mod
+++ b/src/dataset-operator/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/akolb1/gometastore v0.0.0-20221218020403-aaa7217ecd00
 	github.com/go-logr/logr v1.2.4
+	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/kubernetes-csi/csi-test/v5 v5.0.0
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/src/dataset-operator/go.sum
+++ b/src/dataset-operator/go.sum
@@ -157,6 +157,7 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
Adds a new action for creating a release when a tag is pushed to the repo. The action will
1. Build images for the operator and key generator with the given tag
2. Build images for the included CSI plugins (S3, NFS)
3. creates a Helm chart that is hosted in the project github pages
4. makes a Github release

Fixes #259 