### PR TITLE
ci: simplify csi plugin image building pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,26 +39,26 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: Build and push Dataset operator image
-        run: |
-          cd src/dataset-operator
-          ./build_and_push_multiarch_dataset_operator.sh ${{ vars.REGISTRY_URL }} ${{ github.ref_name }}
-      - name: Build and push Generate Keys image 
-        run: |
-          cd src/generate-keys
-          ./build_and_push_multiarch_generate_keys.sh ${{ vars.REGISTRY_URL }} ${{ github.ref_name }}
+            #      - name: Build and push Dataset operator image
+            #        run: |
+            #          cd src/dataset-operator
+            #          ./build_and_push_multiarch_dataset_operator.sh ${{ vars.REGISTRY_URL }} ${{ github.ref_name }}
+            #
+            #      - name: Build and push Generate Keys image 
+            #        run: |
+            #          cd src/generate-keys
+            #          ./build_and_push_multiarch_generate_keys.sh ${{ vars.REGISTRY_URL }} ${{ github.ref_name }}
      
-      - name: Build and push bundled CSI plugins
+      - name: Build and push bundled CSI S3
         run: |
-          cd build-tools
-          make ARCH=amd64 COMMON_IMAGE_TAG=${{ steps.vars.outputs.sha_short }} build-csi-plugins
-          make ARCH=amd64 COMMON_IMAGE_TAG=${{ steps.vars.outputs.sha_short }} push-csi-plugins
-          make ARCH=arm64 COMMON_IMAGE_TAG=${{ steps.vars.outputs.sha_short }} build-csi-plugins
-          make ARCH=arm64 COMMON_IMAGE_TAG=${{ steps.vars.outputs.sha_short }} push-csi-plugins
-          make ARCH=ppc64le COMMON_IMAGE_TAG=${{ steps.vars.outputs.sha_short }} build-csi-plugins 
-          make ARCH=ppc64le COMMON_IMAGE_TAG=${{ steps.vars.outputs.sha_short }} push-csi-plugins 
-          make COMMON_IMAGE_TAG=${{ steps.vars.outputs.sha_short }}  push-multiarch-csi-plugins
+          cd src/csi-s3
+          ./build_and_push_multiarch_csis3.sh ${{ vars.REGISTRY_URL }} ${{ steps.vars.outputs.sha_short }}
 
+      - name: Build and push bundled CSI NFS
+        run: |
+          cd src/csi-driver-nfs
+          ./build_and_push_multiarch_csinfs.sh ${{ vars.REGISTRY_URL }} ${{ steps.vars.outputs.sha_short }}
+ 
       - name: Install Helm
         uses: azure/setup-helm@v3
       

--- a/src/csi-driver-nfs/Dockerfile
+++ b/src/csi-driver-nfs/Dockerfile
@@ -1,13 +1,12 @@
-FROM ubuntu:16.04 as base
+FROM ubuntu:20.04 as base
 RUN apt-get update && \
   apt-get install -y \
   git wget gcc make mercurial && \
   rm -rf /var/lib/apt/lists/*
 
-ARG ARCH
-
-ENV ARCH=$ARCH
-ENV GO_VERSION=1.12.17
+ARG TARGETARCH
+ENV ARCH=$TARGETARCH
+ENV GO_VERSION=1.19
 
 RUN echo $ARCH $GO_VERSION
 

--- a/src/csi-driver-nfs/build_and_push_multiarch_csinfs.sh
+++ b/src/csi-driver-nfs/build_and_push_multiarch_csinfs.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+REGISTRY_URL="${1:-quay.io/datashim-io}"
+VERSION="${2:-latest}"
+docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le --push -t ${REGISTRY_URL}/csi-nfs:${VERSION} .

--- a/src/csi-s3/build_and_push_multiarch_csis3.sh
+++ b/src/csi-s3/build_and_push_multiarch_csis3.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+REGISTRY_URL="${1:-quay.io/datashim-io}"
+VERSION="${2:-latest}"
+docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le --network host  --push -t ${REGISTRY_URL}/csi-s3:${VERSION} .

--- a/src/csi-s3/cmd/s3driver/Dockerfile.full
+++ b/src/csi-s3/cmd/s3driver/Dockerfile.full
@@ -1,4 +1,4 @@
-ARG ARCH
+ARG TARGETARCH
 FROM golang:1.18-alpine3.15 as base
 
 ARG S3BACKER_VERSION=1.5.0
@@ -26,11 +26,10 @@ RUN ls -l && \
 # goofys cannot be built.
 # This instruction can be safely removed once
 # https://github.com/kahing/goofys/issues/740 has been fixed
+# Update: Aug '23 - the fix is merged https://github.com/kahing/goofys/pull/744
 WORKDIR /go/src
 RUN git clone https://github.com/kahing/goofys.git && \
     cd goofys && \
-    git checkout e903e56038fe0325e4538007b6acc064af8164c7 && \ 
-    sed -i -e '/require/ a \\tgolang.org/x/text v0.3.7' go.mod && \
     go mod tidy && \
     go build -o /go/bin/goofys
 


### PR DESCRIPTION
Changes the CSI Plugin build pipeline to entirely use `docker buildx` instead of the complicated Makefiles that we have had before. The Makefiles are still present but will be removed in a future PR