### PR TITLE
fix: remove provision:true as it would cause failures

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -151,8 +151,6 @@ spec:
   url: "https://dax-cdn.cdn.appdomain.cloud/dax-noaa-weather-data-jfk-airport/1.1.4/noaa-weather-data-jfk-airport.tar.gz"
   format: "application/x-tar"
   extract: "true" # <---- OPTIONAL, to extract the content of the archive
-  local:
-    provision: "true" # <---- Required to create a bucket in the backing store
 ```
 
 ## Next steps


### PR DESCRIPTION
I was able to test archive datasets now that #367 has been fixed and it looks like having

```yaml
  local:
    provision: "true" # <---- Required to create a bucket in the backing store
```

causes the following error:

```
An error occurred (BucketAlreadyOwnedByYou) when calling the CreateBucket operation: Your previous request to create the named bucket succeeded and you already own it.
```

This PR removes it, ensuring the example works