### PR TITLE
Removed deprecated secret-namespace references from examples

### DIFF
--- a/examples/templates/example-dataset-s3-provision.yaml
+++ b/examples/templates/example-dataset-s3-provision.yaml
@@ -5,8 +5,7 @@ metadata:
 spec:
   local:
     type: "COS"
-    secret-name: "{SECRET_NAME}" #see s3-secrets.yaml for an example
-    secret-namespace: "{SECRET_NAMESPACE}" #optional if the secret is in the same ns as dataset
+    secret-name: "{SECRET_NAME}" #see s3-secrets.yaml for an example. Must be in the same namespace.
     endpoint: "{S3_SERVICE_URL}"
     bucket: "{BUCKET_NAME}"
     readonly: "true" # default is false

--- a/examples/templates/example-dataset-s3-secrets.yaml
+++ b/examples/templates/example-dataset-s3-secrets.yaml
@@ -5,8 +5,7 @@ metadata:
 spec:
   local:
     type: "COS"
-    secret-name: "{SECRET_NAME}" #see s3-secrets.yaml for an example
-    secret-namespace: "{SECRET_NAMESPACE}" #optional if the secret is in the same ns as dataset
+    secret-name: "{SECRET_NAME}" #see s3-secrets.yaml for an example. Must be in the same namespace.
     endpoint: "{S3_SERVICE_URL}"
     bucket: "{BUCKET_NAME}"
     readonly: "true" # default is false


### PR DESCRIPTION
Caused by #146 
Solves #370 

I spent a while struggling with this, since I copied the examples and they weren't entirely applicable :( Hoping this helps others.